### PR TITLE
Add ESP32 BME280 WiFi/Ethernet MQTT example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# ESP32-S3-ETH PoE with BME280
+
+This sketch configures an ESP32-S3-ETH PoE board as a WiFi access point to update settings for Ethernet and MQTT. Measurements from a BME280 sensor are sent via MQTT over Ethernet at a configurable interval.
+
+## Wiring
+
+```
+ESP32-S3-ETH PoE        BME280
+--------------------    ------
+3V3 (3.3V)  ----------> VIN
+GND          ----------> GND
+GPIO10 (SDA) ----------> SDA
+GPIO11 (SCL) ----------> SCL
+```
+
+Ethernet is built into the PoE board using the RJ45 connector.
+
+## Configuration Website
+
+1. After flashing, the device starts an access point named **ESP32_CONFIG** with password **password**.
+2. Connect to this network and browse to `http://192.168.4.1/` to view the configuration page.
+3. Update the Ethernet IP, MQTT settings, sampling time, and tag names. When saved the configuration is stored in flash.
+
+Configuration can also be updated by publishing a JSON document to the MQTT topic `esp32/config` while MQTT is enabled.
+
+## Building
+
+Use the Arduino IDE or PlatformIO with the ESP32 board package. The entry point is `src/main.cpp`.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,181 @@
+#include <WiFi.h>
+#include <WebServer.h>
+#include <ETH.h>
+#include <Preferences.h>
+#include <PubSubClient.h>
+#include <Adafruit_BME280.h>
+#include <ArduinoJson.h>
+
+#define I2C_SDA 10
+#define I2C_SCL 11
+
+Adafruit_BME280 bme;
+WiFiClient ethClient;
+PubSubClient mqttClient(ethClient);
+WebServer server(80);
+Preferences prefs;
+
+struct Config {
+    String eth_ip = "192.168.1.50";
+    String eth_gateway = "192.168.1.1";
+    String eth_subnet = "255.255.255.0";
+    bool mqtt_enabled = false;
+    String mqtt_server = "192.168.1.100";
+    uint16_t mqtt_port = 1883;
+    String mqtt_topic = "esp32/data";
+    uint32_t sampling_time_ms = 5000;
+    String tag_temp = "Temperature1";
+    String tag_press = "Pressure1";
+    String tag_hum = "Humidity1";
+} config;
+
+void loadConfig() {
+    prefs.begin("cfg", true);
+    config.eth_ip = prefs.getString("ip", config.eth_ip);
+    config.eth_gateway = prefs.getString("gw", config.eth_gateway);
+    config.eth_subnet = prefs.getString("sn", config.eth_subnet);
+    config.mqtt_enabled = prefs.getBool("mqtt_en", config.mqtt_enabled);
+    config.mqtt_server = prefs.getString("mqtt_server", config.mqtt_server);
+    config.mqtt_port = prefs.getUShort("mqtt_port", config.mqtt_port);
+    config.mqtt_topic = prefs.getString("mqtt_topic", config.mqtt_topic);
+    config.sampling_time_ms = prefs.getUInt("sample", config.sampling_time_ms);
+    config.tag_temp = prefs.getString("tag_temp", config.tag_temp);
+    config.tag_press = prefs.getString("tag_press", config.tag_press);
+    config.tag_hum = prefs.getString("tag_hum", config.tag_hum);
+    prefs.end();
+}
+
+void saveConfig() {
+    prefs.begin("cfg", false);
+    prefs.putString("ip", config.eth_ip);
+    prefs.putString("gw", config.eth_gateway);
+    prefs.putString("sn", config.eth_subnet);
+    prefs.putBool("mqtt_en", config.mqtt_enabled);
+    prefs.putString("mqtt_server", config.mqtt_server);
+    prefs.putUShort("mqtt_port", config.mqtt_port);
+    prefs.putString("mqtt_topic", config.mqtt_topic);
+    prefs.putUInt("sample", config.sampling_time_ms);
+    prefs.putString("tag_temp", config.tag_temp);
+    prefs.putString("tag_press", config.tag_press);
+    prefs.putString("tag_hum", config.tag_hum);
+    prefs.end();
+}
+
+void handleRoot() {
+    String page = "<html><body><h1>ESP32 Config</h1><form method='POST' action='/save'>";
+    page += "Ethernet IP: <input name='ip' value='" + config.eth_ip + "'><br>";
+    page += "Gateway: <input name='gw' value='" + config.eth_gateway + "'><br>";
+    page += "Subnet: <input name='sn' value='" + config.eth_subnet + "'><br>";
+    page += "MQTT Enabled: <input type='checkbox' name='mqtt_en'" + String(config.mqtt_enabled?" checked":"") + "><br>";
+    page += "MQTT Server: <input name='mqtt_server' value='" + config.mqtt_server + "'><br>";
+    page += "MQTT Port: <input name='mqtt_port' value='" + String(config.mqtt_port) + "'><br>";
+    page += "MQTT Topic: <input name='mqtt_topic' value='" + config.mqtt_topic + "'><br>";
+    page += "Sampling Time(ms): <input name='sample' value='" + String(config.sampling_time_ms) + "'><br>";
+    page += "Temp Tag: <input name='tag_temp' value='" + config.tag_temp + "'><br>";
+    page += "Press Tag: <input name='tag_press' value='" + config.tag_press + "'><br>";
+    page += "Hum Tag: <input name='tag_hum' value='" + config.tag_hum + "'><br>";
+    page += "<input type='submit' value='Save'></form></body></html>";
+    server.send(200, "text/html", page);
+}
+
+void handleSave() {
+    if(server.hasArg("ip")) config.eth_ip = server.arg("ip");
+    if(server.hasArg("gw")) config.eth_gateway = server.arg("gw");
+    if(server.hasArg("sn")) config.eth_subnet = server.arg("sn");
+    config.mqtt_enabled = server.hasArg("mqtt_en");
+    if(server.hasArg("mqtt_server")) config.mqtt_server = server.arg("mqtt_server");
+    if(server.hasArg("mqtt_port")) config.mqtt_port = server.arg("mqtt_port").toInt();
+    if(server.hasArg("mqtt_topic")) config.mqtt_topic = server.arg("mqtt_topic");
+    if(server.hasArg("sample")) config.sampling_time_ms = server.arg("sample").toInt();
+    if(server.hasArg("tag_temp")) config.tag_temp = server.arg("tag_temp");
+    if(server.hasArg("tag_press")) config.tag_press = server.arg("tag_press");
+    if(server.hasArg("tag_hum")) config.tag_hum = server.arg("tag_hum");
+    saveConfig();
+    server.sendHeader("Location", "/");
+    server.send(303);
+}
+
+void mqttCallback(char* topic, byte* payload, unsigned int len) {
+    StaticJsonDocument<256> doc;
+    DeserializationError err = deserializeJson(doc, payload, len);
+    if(err) return;
+    if(doc.containsKey("ip")) config.eth_ip = doc["ip"].as<String>();
+    if(doc.containsKey("gw")) config.eth_gateway = doc["gw"].as<String>();
+    if(doc.containsKey("sn")) config.eth_subnet = doc["sn"].as<String>();
+    if(doc.containsKey("mqtt_enabled")) config.mqtt_enabled = doc["mqtt_enabled"].as<bool>();
+    if(doc.containsKey("mqtt_server")) config.mqtt_server = doc["mqtt_server"].as<String>();
+    if(doc.containsKey("mqtt_port")) config.mqtt_port = doc["mqtt_port"].as<uint16_t>();
+    if(doc.containsKey("mqtt_topic")) config.mqtt_topic = doc["mqtt_topic"].as<String>();
+    if(doc.containsKey("sample")) config.sampling_time_ms = doc["sample"].as<uint32_t>();
+    if(doc.containsKey("tag_temp")) config.tag_temp = doc["tag_temp"].as<String>();
+    if(doc.containsKey("tag_press")) config.tag_press = doc["tag_press"].as<String>();
+    if(doc.containsKey("tag_hum")) config.tag_hum = doc["tag_hum"].as<String>();
+    saveConfig();
+}
+
+void connectMQTT() {
+    if(!config.mqtt_enabled) return;
+    mqttClient.setServer(config.mqtt_server.c_str(), config.mqtt_port);
+    mqttClient.setCallback(mqttCallback);
+    while(!mqttClient.connected()) {
+        mqttClient.connect("esp32");
+        delay(500);
+    }
+    mqttClient.subscribe("esp32/config");
+}
+
+unsigned long lastPublish = 0;
+
+void setup() {
+    Serial.begin(115200);
+    loadConfig();
+
+    // Start I2C and BME280
+    Wire.begin(I2C_SDA, I2C_SCL);
+    bme.begin(0x76);
+
+    // Start Ethernet
+    ETH.begin();
+    IPAddress ip, gw, sn;
+    ip.fromString(config.eth_ip);
+    gw.fromString(config.eth_gateway);
+    sn.fromString(config.eth_subnet);
+    ETH.config(ip, gw, gw, sn);
+
+    // Start WiFi AP for config
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP("ESP32_CONFIG", "password");
+
+    // Web server routes
+    server.on("/", handleRoot);
+    server.on("/save", HTTP_POST, handleSave);
+    server.begin();
+
+    connectMQTT();
+}
+
+void loop() {
+    server.handleClient();
+    if(config.mqtt_enabled && !mqttClient.connected()) {
+        connectMQTT();
+    }
+    mqttClient.loop();
+
+    unsigned long now = millis();
+    if(now - lastPublish > config.sampling_time_ms) {
+        lastPublish = now;
+        float t = bme.readTemperature();
+        float p = bme.readPressure() / 100.0F;
+        float h = bme.readHumidity();
+        StaticJsonDocument<128> doc;
+        doc[config.tag_temp] = t;
+        doc[config.tag_press] = p;
+        doc[config.tag_hum] = h;
+        char buf[128];
+        size_t n = serializeJson(doc, buf);
+        if(config.mqtt_enabled) {
+            mqttClient.publish(config.mqtt_topic.c_str(), buf, n);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add program for ESP32-S3-ETH PoE that reads BME280
- expose WiFi hotspot configuration webpage
- allow configuration via MQTT
- document wiring and setup instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68408660d0c08324a1d54179488668fa